### PR TITLE
The new CSecurityManager only takes a string for its cryptAlgorithm

### DIFF
--- a/golive/services/GoLive_SecurityService.php
+++ b/golive/services/GoLive_SecurityService.php
@@ -116,12 +116,7 @@ class GoLive_SecurityService extends SecurityService {
     $this->securityManager = new CSecurityManager();
     $this->securityManager->init();
 
-    $this->securityManager->cryptAlgorithm = array(
-      'rijndael-256',
-      '',
-      'cbc',
-      ''
-    );
+    $this->securityManager->cryptAlgorithm = 'rijndael-256';
 
     $this->securityManager->setEncryptionKey($this->_getEncryptionKey());
   }


### PR DESCRIPTION
@jpwdesigns @thegodshatetexas: Fixes #4. It's surprising that this worked before, because the `cryptAlgorithm` property was a string in Craft 2.3, too.
