### PR TITLE
Never update tasks in deployment.

### DIFF
--- a/golive/etc/db/GoLive_DbBackup.php
+++ b/golive/etc/db/GoLive_DbBackup.php
@@ -48,6 +48,7 @@ class GoLive_DbBackup extends DbBackup
     'assetindexdata',
     'assettransformindex',
     'sessions',
+    'tasks',
     'templatecaches',
     'templatecachecriteria',
     'templatecacheelements'


### PR DESCRIPTION
@ktbartholomew If tasks are included in backup, prod servers get the golive tasks copied over which is not good. Tasks should be relative to environment.
